### PR TITLE
Fix Date.toString calculation

### DIFF
--- a/common/js/content.js
+++ b/common/js/content.js
@@ -62,23 +62,23 @@ function setDate(element) {
                 MyDate.prototype.toUTCStringOriginal = Date.prototype.toUTCString;
                 MyDate.prototype.toISOStringOriginal = Date.prototype.toISOString;
                 
-                function toStringConstructor(method) {
-                    var date = new MyDate();
+				function toStringConstructor(that, method) {
+                    var date = new MyDate(that);
                     date.setUTCHours(date.getHours() - ${utcShift});
 
                     return date[method]();
                 }
                 
                 MyDate.prototype.toGMTString = function() {
-                    return toStringConstructor('toGMTStringOriginal');
+                    return toStringConstructor(this, 'toGMTStringOriginal');
                 };
                 
                 MyDate.prototype.toUTCString = function() {
-                    return toStringConstructor('toUTCStringOriginal');
+                    return toStringConstructor(this, 'toUTCStringOriginal');
                 };
                 
                 MyDate.prototype.toISOString = function() {
-                    return toStringConstructor('toISOStringOriginal');
+                    return toStringConstructor(this, 'toISOStringOriginal');
                 };
             
                 var names = Object.getOwnPropertyNames(Date);

--- a/common/js/content.js
+++ b/common/js/content.js
@@ -62,7 +62,7 @@ function setDate(element) {
                 MyDate.prototype.toUTCStringOriginal = Date.prototype.toUTCString;
                 MyDate.prototype.toISOStringOriginal = Date.prototype.toISOString;
                 
-				function toStringConstructor(that, method) {
+		function toStringConstructor(that, method) {
                     var date = new MyDate(that);
                     date.setUTCHours(date.getHours() - ${utcShift});
 


### PR DESCRIPTION
Fix a bug where, when Proxy Time is enabled, creating a Date object, then adding some time to it and converting it to a string would result in the current time being returned, instead of the calculated time.